### PR TITLE
feat: Add support for multi-tenant deployments

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -94,14 +94,29 @@ def iter_mfes() -> t.Iterable[tuple[str, MFE_ATTRS_TYPE]]:
     """
     yield from MFE_APPS.apply({}).items()
 
-def iter_domains(additional_domains, main_host, main_theme):
+def iter_domains(additional_domains: list[dict[str, str]], main_host:str, main_theme:str) -> t.Iterable[tuple[str, str]]:
     """
-    Yield:
+    Iterate over all domains that have an MFE enabled.
 
-        (name, theme)
+    It yields the name (domain) of each site and its corresponding theme.
+
+    Args:
+        additional_domains (list): A list of additional domain configurations.
+            Each domain configuration is a dictionary that should contain the keys 'domain',
+            'mfe_proxy', and 'mfe_theme'. The 'domain' key should contain the domain of the site,
+            the 'mfe_proxy' key should be set to the backend serving MFEs, but here it just
+            indicates whether MFEs are enabled for the site, and the 'mfe_theme' key should
+            contain the name of theme of the site.
+        main_host (str): The name of the main site.
+        main_theme (str): The theme of the main site.
+
+    Yield:
+        tuple[str, str]: A tuple containing the name (domain) and theme of each site.
     """
     yield main_host, main_theme
     for domain_config in additional_domains:
+        # If the domain has an mfe_proxy field it is serving MFEs. If it has mfe_theme set
+        # then we need to build a separate set of MFEs for it.
         if 'mfe_proxy' in domain_config and 'mfe_theme' in domain_config:
             yield domain_config['domain'], domain_config['mfe_theme']
 

--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -19,6 +19,7 @@ config = {
         "HOST": "apps.{{ LMS_HOST }}",
         "COMMON_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
         "CADDY_DOCKER_IMAGE": "{{ DOCKER_IMAGE_CADDY }}",
+        "BRAND_PACKAGE_NAME": "",
     },
 }
 
@@ -269,49 +270,3 @@ tutor_hooks.Filters.CONFIG_UNIQUE.add_items(
 tutor_hooks.Filters.CONFIG_OVERRIDES.add_items(
     list(config.get("overrides", {}).items())
 )
-
-
-# mfe_theme_patch = """
-# RUN mkdir -p /openedx/themes
-# COPY ./themes /openedx/themes
-# RUN npm install '@edx/brand@file:/openedx/themes/{}/'
-# """
-#
-#
-# def get_additional_mfe_domains_with_theme(config):
-#
-    # # We are only concerned about MFEs that are using a custom theme, for the
-    # # rest the existing mfe_proxy works.
-    # additional_domains = config.get('GROVE_ADDITIONAL_DOMAINS', [])
-    # for domain_config in additional_domains:
-        # if 'mfe_proxy' in domain_config and 'mfe_theme' in domain_config:
-            # yield domain_config
-#
-#
-# @tutor_hooks.Actions.PROJECT_ROOT_READY.add(priority=11)
-# def _build_mfes_for_additional_domains(root):
-    # config = tutor_config.load_minimal(root)
-    # mfe_domains = list(get_additional_mfe_domains_with_theme(config))
-    # # The default is the list of all supported MFEs in tutor 16.
-    # enabled_mfes = tutor_config.load_minimal(root).get(
-        # "GROVE_ENABLED_MFES",
-        # [
-            # "authn", "account", "communications", "course-authoring",
-            # "discussions", "gradebook", "learning", "ora-grading", "profile"
-        # ]
-    # )
-    # print("----------------------------->")
-#
-#
-    # # for mfe in enabled_mfes:
-    # for domain_config in mfe_domains:
-        # # In the master branch of tutor-mfe, we have the ability to patch
-        # # post-npm-install on a per-mfe basis.
-        # # This will install the specific theme for a site for this MFE.
-        # tutor_hooks.Filters.ENV_PATCHES.add_items([
-            # (
-                # f"mfe-dockerfile-post-npm-install-domain-{domain_config['domain']}",
-                # mfe_theme_patch.format(domain_config['mfe_theme']),
-            # )
-#
-        # ])

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -11,16 +11,18 @@
             }
         }
     }
-
+    {% for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
     {% for app_name, app in iter_mfes() %}
-    @mfe_{{ app_name }} {
+    @mfe_{{ app_name }}_{{ domain }} {
+        host {{ domain }}
         path /{{ app_name }} /{{ app_name }}/*
     }
-    handle @mfe_{{ app_name }} {
+    handle @mfe_{{ app_name }}_{{ domain }} {
         uri strip_prefix /{{ app_name }}
-        root * /openedx/dist/{{ app_name }}
+        root * /openedx/dist/{{ app_name }}-{{ domain }}
         try_files /{path} /index.html
         file_server
     }
+    {% endfor %}
     {% endfor %}
 }

--- a/tutormfe/templates/mfe/apps/mfe/Caddyfile
+++ b/tutormfe/templates/mfe/apps/mfe/Caddyfile
@@ -11,7 +11,7 @@
             }
         }
     }
-    {% for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
+    {% for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
     {% for app_name, app in iter_mfes() %}
     @mfe_{{ app_name }}_{{ domain }} {
         host {{ domain }}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=i18n /openedx/i18n/i18n-merge.js /openedx/i18n/i18n-merge.js
 RUN stat /openedx/app/src/i18n/messages 2> /dev/null || (echo "missing messages folder" && mkdir -p /openedx/app/src/i18n/messages)
 RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ app_name }} /openedx/app/src/i18n/messages
 
-{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
+{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
 ######## {{ app_name }} for {{ domain }} (common)
 FROM base AS {{ app_name }}-{{ domain }}-common
 COPY --from={{ app_name }}-src /package.json /openedx/app/package.json
@@ -61,14 +61,16 @@ ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("mfe-dockerfile-pre-npm-install") }}
 {{ patch("mfe-dockerfile-pre-npm-install-{}".format(app_name)) }}
 {{ patch("mfe-dockerfile-pre-npm-install-domain-{}".format(domain)) }}
-RUN mkdir -p /openedx/themes
-COPY ./themes /openedx/themes
-RUN npm install '@edx/brand@file:/openedx/themes/{{ theme }}/'
 {#- Required for building optipng on M1 #}
 ENV CPPFLAGS=-DPNG_ARM_NEON_OPT=0
 {#- We define this environment variable to bypass an issue with the installation of pact https://github.com/pact-foundation/pact-js-core/issues/264 #}
 ENV PACT_SKIP_BINARY_INSTALL=true
 RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %}npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY
+{%- if theme %}
+RUN mkdir -p /openedx/themes
+COPY ./themes /openedx/themes
+RUN npm install '@edx/brand@file:/openedx/themes/{{ theme }}/'
+{%- endif %}
 {{ patch("mfe-dockerfile-post-npm-install") }}
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 {{ patch("mfe-dockerfile-post-npm-install-domain-{}".format(domain)) }}
@@ -92,7 +94,7 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 {% endfor %}
 
 # Production images are last to accelerate dev image building
-{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
+{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
 {%- for app_name, app in iter_mfes() %}
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-{{ domain }}-common AS {{ app_name }}-{{ domain }}-prod
@@ -107,7 +109,7 @@ FROM {{ MFE_CADDY_DOCKER_IMAGE }} as production
 RUN mkdir -p /openedx/dist
 
 # Copy static assets
-{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
+{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
 {% for app_name, app in iter_mfes() %}
 COPY --from={{ app_name }}-{{ domain }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}-{{ domain }}
 {% endfor %}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -52,30 +52,33 @@ COPY --from=i18n /openedx/i18n/i18n-merge.js /openedx/i18n/i18n-merge.js
 RUN stat /openedx/app/src/i18n/messages 2> /dev/null || (echo "missing messages folder" && mkdir -p /openedx/app/src/i18n/messages)
 RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ app_name }} /openedx/app/src/i18n/messages
 
+######## {{ app_name }} (common)
+FROM base AS {{ app_name }}-common
 {%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-######## {{ app_name }} for {{ domain }} (common)
-FROM base AS {{ app_name }}-{{ domain }}-common
-COPY --from={{ app_name }}-src /package.json /openedx/app/package.json
-COPY --from={{ app_name }}-src /package-lock.json /openedx/app/package-lock.json
+COPY --from={{ app_name }}-src /package.json /openedx/app/{{ domain }}/package.json
+COPY --from={{ app_name }}-src /package-lock.json /openedx/app/{{ domain }}/package-lock.json
+{%- endfor %}
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("mfe-dockerfile-pre-npm-install") }}
 {{ patch("mfe-dockerfile-pre-npm-install-{}".format(app_name)) }}
-{{ patch("mfe-dockerfile-pre-npm-install-domain-{}".format(domain)) }}
 {#- Required for building optipng on M1 #}
 ENV CPPFLAGS=-DPNG_ARM_NEON_OPT=0
 {#- We define this environment variable to bypass an issue with the installation of pact https://github.com/pact-foundation/pact-js-core/issues/264 #}
 ENV PACT_SKIP_BINARY_INSTALL=true
-RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %}npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY
-{%- if theme %}
 RUN mkdir -p /openedx/themes
 COPY ./themes /openedx/themes
+
+{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
+RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %} cd {{ domain }} && npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY
+{%- if theme %}
 RUN npm install '@edx/brand@file:/openedx/themes/{{ theme }}/'
 {%- endif %}
 {{ patch("mfe-dockerfile-post-npm-install") }}
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
 {{ patch("mfe-dockerfile-post-npm-install-domain-{}".format(domain)) }}
-COPY --from={{ app_name }}-src / /openedx/app
-COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
+COPY --from={{ app_name }}-src / /openedx/app/{{ domain }}
+COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/app/{{ domain }}/src/i18n/messages
+{%- endfor %}
 EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time
@@ -86,7 +89,7 @@ ENV PUBLIC_PATH='/{{ app_name }}/'
 # So we point to a relative url that will be a proxy for the LMS.
 ENV MFE_CONFIG_API_URL=/api/mfe_config/v1
 ARG ENABLE_NEW_RELIC=false
-{% endfor %}
+
 ######## {{ app_name }} (dev)
 FROM {{ app_name }}-common AS {{ app_name }}-dev
 ENV NODE_ENV=development
@@ -94,12 +97,12 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 {% endfor %}
 
 # Production images are last to accelerate dev image building
-{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
 {%- for app_name, app in iter_mfes() %}
 ######## {{ app_name }} (production)
-FROM {{ app_name }}-{{ domain }}-common AS {{ app_name }}-{{ domain }}-prod
+FROM {{ app_name }}-common AS {{ app_name }}-prod
 ENV NODE_ENV=production
-RUN npm run build
+{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
+RUN cd {{ domain }} && npm run build
 {% endfor %}
 {% endfor %}
 
@@ -111,6 +114,6 @@ RUN mkdir -p /openedx/dist
 # Copy static assets
 {%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
 {% for app_name, app in iter_mfes() %}
-COPY --from={{ app_name }}-{{ domain }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}-{{ domain }}
+COPY --from={{ app_name }}-prod /openedx/app/{{ domain }}/dist /openedx/dist/{{ app_name }}-{{ domain }}
 {% endfor %}
 {% endfor %}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -52,13 +52,18 @@ COPY --from=i18n /openedx/i18n/i18n-merge.js /openedx/i18n/i18n-merge.js
 RUN stat /openedx/app/src/i18n/messages 2> /dev/null || (echo "missing messages folder" && mkdir -p /openedx/app/src/i18n/messages)
 RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ app_name }} /openedx/app/src/i18n/messages
 
-######## {{ app_name }} (common)
-FROM base AS {{ app_name }}-common
+{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
+######## {{ app_name }} for {{ domain }} (common)
+FROM base AS {{ app_name }}-{{ domain }}-common
 COPY --from={{ app_name }}-src /package.json /openedx/app/package.json
 COPY --from={{ app_name }}-src /package-lock.json /openedx/app/package-lock.json
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("mfe-dockerfile-pre-npm-install") }}
 {{ patch("mfe-dockerfile-pre-npm-install-{}".format(app_name)) }}
+{{ patch("mfe-dockerfile-pre-npm-install-domain-{}".format(domain)) }}
+RUN mkdir -p /openedx/themes
+COPY ./themes /openedx/themes
+RUN npm install '@edx/brand@file:/openedx/themes/{{ theme }}/'
 {#- Required for building optipng on M1 #}
 ENV CPPFLAGS=-DPNG_ARM_NEON_OPT=0
 {#- We define this environment variable to bypass an issue with the installation of pact https://github.com/pact-foundation/pact-js-core/issues/264 #}
@@ -66,6 +71,7 @@ ENV PACT_SKIP_BINARY_INSTALL=true
 RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %}npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY
 {{ patch("mfe-dockerfile-post-npm-install") }}
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
+{{ patch("mfe-dockerfile-post-npm-install-domain-{}".format(domain)) }}
 COPY --from={{ app_name }}-src / /openedx/app
 COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
 EXPOSE {{ app['port'] }}
@@ -78,7 +84,7 @@ ENV PUBLIC_PATH='/{{ app_name }}/'
 # So we point to a relative url that will be a proxy for the LMS.
 ENV MFE_CONFIG_API_URL=/api/mfe_config/v1
 ARG ENABLE_NEW_RELIC=false
-
+{% endfor %}
 ######## {{ app_name }} (dev)
 FROM {{ app_name }}-common AS {{ app_name }}-dev
 ENV NODE_ENV=development
@@ -86,11 +92,13 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 {% endfor %}
 
 # Production images are last to accelerate dev image building
+{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
 {%- for app_name, app in iter_mfes() %}
 ######## {{ app_name }} (production)
-FROM {{ app_name }}-common AS {{ app_name }}-prod
+FROM {{ app_name }}-{{ domain }}-common AS {{ app_name }}-{{ domain }}-prod
 ENV NODE_ENV=production
 RUN npm run build
+{% endfor %}
 {% endfor %}
 
 ####### final production image with all static assets
@@ -99,6 +107,8 @@ FROM {{ MFE_CADDY_DOCKER_IMAGE }} as production
 RUN mkdir -p /openedx/dist
 
 # Copy static assets
+{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, GROVE_COMPREHENSIVE_THEME_BRAND_PACKAGE_NAME) %}
 {% for app_name, app in iter_mfes() %}
-COPY --from={{ app_name }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}
+COPY --from={{ app_name }}-{{ domain }}-prod /openedx/app/dist /openedx/dist/{{ app_name }}-{{ domain }}
+{% endfor %}
 {% endfor %}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update \
     # https://www.npmjs.com/package/canvas
     libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
-RUN mkdir -p /openedx/app /openedx/env
+RUN mkdir -p /openedx/app /openedx/env /openedx/base
 WORKDIR /openedx/app
 ENV PATH ./node_modules/.bin:${PATH}
 
@@ -54,15 +54,15 @@ RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ 
 
 ######## {{ app_name }} (common)
 FROM base AS {{ app_name }}-common
-COPY --from={{ app_name }}-src /package.json /openedx/app/package.json
-COPY --from={{ app_name }}-src /package-lock.json /openedx/app/package-lock.json
-RUN echo "copying files"\
-{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-    && mkdir -p /openedx/app/{{ domain }} \
-    && cp /openedx/app/package.json /openedx/app/{{ domain }}/package.json \
-    && cp /openedx/app/package-lock.json /openedx/app/{{ domain }}/package-lock.json \
-{%- endfor %}
-    && echo "done"
+COPY --from={{ app_name }}-src /package.json /openedx/base/package.json
+COPY --from={{ app_name }}-src /package-lock.json /openedx/base/package-lock.json
+#RUN echo "copying files" \
+#{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
+#    && mkdir -p /openedx/app/{{ domain }} \
+#    && cp /openedx/app/package.json /openedx/app/{{ domain }}/package.json \
+#    && cp /openedx/app/package-lock.json /openedx/app/{{ domain }}/package-lock.json \
+#{%- endfor %}
+#    && echo "done"
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("mfe-dockerfile-pre-npm-install") }}
 {{ patch("mfe-dockerfile-pre-npm-install-{}".format(app_name)) }}
@@ -73,13 +73,11 @@ ENV PACT_SKIP_BINARY_INSTALL=true
 RUN mkdir -p /openedx/themes
 COPY ./themes /openedx/themes
 
-RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %} echo "building MFEs" \
-{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-  && npm clean-install --prefix={{domain}} --no-audit --no-fund --registry=$NPM_REGISTRY \
-{%- if theme %}
-  && npm install --prefix={{domain}} '@edx/brand@file:/openedx/themes/{{ theme }}/' \
-{%- endif %}
-{%- endfor %}
+RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %} echo "installing packages" \
+  && npm clean-install --prefix="/openedx/base" --no-audit --no-fund --registry=$NPM_REGISTRY \
+#{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
+#  && cp -r /openedx/base/. ./{{domain}}/ \
+#{%- endfor %}
   && echo "done"
 {{ patch("mfe-dockerfile-post-npm-install") }}
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
@@ -87,7 +85,10 @@ COPY --from={{ app_name }}-src / /openedx/base
 COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/base/src/i18n/messages
 RUN echo "copying" \
 {%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-  && cp -r /openedx/base/* /openedx/app/{{ domain }}/ \
+  && cp -r /openedx/base/. /openedx/app/{{ domain }} \
+{%- if theme %}
+  && npm install --prefix={{domain}} '@edx/brand@file:/openedx/themes/{{ theme }}/' \
+{%- endif %}
 {%- endfor %}
   && echo "done"
 EXPOSE {{ app['port'] }}
@@ -113,12 +114,11 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 FROM {{ app_name }}-common AS {{ app_name }}-prod
 ENV NODE_ENV=production
 
-RUN echo "building mfes" && mkdir -p /openedx/dist && ls -lah \
+RUN echo "building mfes" && mkdir -p /openedx/dist \
 {%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-  && ls -lah {{domain}} \
   && npm run --prefix={{ domain }} build  \
   && mkdir -p /openedx/dist/{{ app_name }}-{{ domain }} \
-  && cp -r {{domain}}/dist/* /openedx/dist/{{ app_name }}-{{ domain }} \
+  && cp -r {{domain}}/dist/. /openedx/dist/{{ app_name }}-{{ domain }}/ \
 {%- endfor %}
   && echo "done"
 {%- endfor %}

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -54,10 +54,15 @@ RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ 
 
 ######## {{ app_name }} (common)
 FROM base AS {{ app_name }}-common
+COPY --from={{ app_name }}-src /package.json /openedx/app/package.json
+COPY --from={{ app_name }}-src /package-lock.json /openedx/app/package-lock.json
+RUN echo "copying files"\
 {%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-COPY --from={{ app_name }}-src /package.json /openedx/app/{{ domain }}/package.json
-COPY --from={{ app_name }}-src /package-lock.json /openedx/app/{{ domain }}/package-lock.json
+    && mkdir -p /openedx/app/{{ domain }} \
+    && cp /openedx/app/package.json /openedx/app/{{ domain }}/package.json \
+    && cp /openedx/app/package-lock.json /openedx/app/{{ domain }}/package-lock.json \
 {%- endfor %}
+    && echo "done"
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 {{ patch("mfe-dockerfile-pre-npm-install") }}
 {{ patch("mfe-dockerfile-pre-npm-install-{}".format(app_name)) }}
@@ -68,17 +73,23 @@ ENV PACT_SKIP_BINARY_INSTALL=true
 RUN mkdir -p /openedx/themes
 COPY ./themes /openedx/themes
 
+RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %} echo "building MFEs" \
 {%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/root/.npm,sharing=shared {% endif %} cd {{ domain }} && npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY
+  && npm clean-install --prefix={{domain}} --no-audit --no-fund --registry=$NPM_REGISTRY \
 {%- if theme %}
-RUN npm install '@edx/brand@file:/openedx/themes/{{ theme }}/'
+  && npm install --prefix={{domain}} '@edx/brand@file:/openedx/themes/{{ theme }}/' \
 {%- endif %}
+{%- endfor %}
+  && echo "done"
 {{ patch("mfe-dockerfile-post-npm-install") }}
 {{ patch("mfe-dockerfile-post-npm-install-{}".format(app_name)) }}
-{{ patch("mfe-dockerfile-post-npm-install-domain-{}".format(domain)) }}
-COPY --from={{ app_name }}-src / /openedx/app/{{ domain }}
-COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/app/{{ domain }}/src/i18n/messages
+COPY --from={{ app_name }}-src / /openedx/base
+COPY --from={{ app_name }}-i18n /openedx/app/src/i18n/messages /openedx/base/src/i18n/messages
+RUN echo "copying" \
+{%- for domain, theme in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
+  && cp -r /openedx/base/* /openedx/app/{{ domain }}/ \
 {%- endfor %}
+  && echo "done"
 EXPOSE {{ app['port'] }}
 
 # Configuration needed at build time
@@ -101,10 +112,16 @@ CMD ["/bin/bash", "-c", "npm run start --- --config ./webpack.dev-tutor.config.j
 ######## {{ app_name }} (production)
 FROM {{ app_name }}-common AS {{ app_name }}-prod
 ENV NODE_ENV=production
+
+RUN echo "building mfes" && mkdir -p /openedx/dist && ls -lah \
 {%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
-RUN cd {{ domain }} && npm run build
-{% endfor %}
-{% endfor %}
+  && ls -lah {{domain}} \
+  && npm run --prefix={{ domain }} build  \
+  && mkdir -p /openedx/dist/{{ app_name }}-{{ domain }} \
+  && cp -r {{domain}}/dist/* /openedx/dist/{{ app_name }}-{{ domain }} \
+{%- endfor %}
+  && echo "done"
+{%- endfor %}
 
 ####### final production image with all static assets
 FROM {{ MFE_CADDY_DOCKER_IMAGE }} as production
@@ -112,8 +129,6 @@ FROM {{ MFE_CADDY_DOCKER_IMAGE }} as production
 RUN mkdir -p /openedx/dist
 
 # Copy static assets
-{%- for domain, domain_config in iter_domains(GROVE_ADDITIONAL_DOMAINS, MFE_HOST, MFE_BRAND_PACKAGE_NAME) %}
 {% for app_name, app in iter_mfes() %}
-COPY --from={{ app_name }}-prod /openedx/app/{{ domain }}/dist /openedx/dist/{{ app_name }}-{{ domain }}
-{% endfor %}
+COPY --from={{ app_name }}-prod /openedx/dist/ /openedx/dist/
 {% endfor %}


### PR DESCRIPTION
This creates a temporary fork of tutor-mfe to add support for deploying a themed batch of MFEs for each tenant. 

It uses Grove's mechanisms for additional domains. 